### PR TITLE
TDE-10: Refactor shaders

### DIFF
--- a/3DEngine/Main.cpp
+++ b/3DEngine/Main.cpp
@@ -29,7 +29,6 @@ DrawListUptr dlIllum;
 DrawListUptr dlDepth;
 DrawListUptr dlShadowMapped;
 DrawListUptr dlTrans;
-DrawListUptr dlText;
 DrawListUptr dlSkybox;
 
 int main() {
@@ -40,28 +39,19 @@ int main() {
     Window &window = Game::GetWindow();
 
     // Setup shaders
-    ShaderSptr lightingShader = ResourceManager<Shader>::Create("Lighting");
-    lightingShader->setPreprocessor(GL_FRAGMENT_SHADER, "MAX_LIGHTS", MAX_LIGHTS);
-    lightingShader->compile();
+    PreprocessorList lightingShaderPreprocessors = {{GL_FRAGMENT_SHADER, "MAX_LIGHTS", MAX_LIGHTS}};
+    auto lightingShader = ResourceManager<Shader>::Create("Lighting", lightingShaderPreprocessors);
 
-    ShaderSptr depthShader = ResourceManager<Shader>::Create("Depth");
-    depthShader->compile();
+    auto depthShader = ResourceManager<Shader>::Create("Depth");
+    depthShader->use();
     depthShader->setInt("depthMap", 0);
     depthShader->setFloat("nearPlane", 1.0f);
     depthShader->setFloat("farPlane", 20.0f);
     depthShader->setBool("isPerspective", true);
 
-    ShaderSptr smdShader = ResourceManager<Shader>::Create("ShadowMappingDepth");
-    smdShader->compile();
-
-    ShaderSptr liParticleShader = ResourceManager<Shader>::Create("LightIconParticle");
-    liParticleShader->compile();
-
-    ShaderSptr textShader = ResourceManager<Shader>::Create("Text");
-    textShader->compile();
-
-    ShaderSptr skyboxShader = ResourceManager<Shader>::Create("Skybox");
-    skyboxShader->compile();
+    auto smdShader = ResourceManager<Shader>::Create("ShadowMappingDepth");
+    auto liParticleShader = ResourceManager<Shader>::Create("LightIconParticle");
+    auto skyboxShader = ResourceManager<Shader>::Create("Skybox");
 
     // Setup scene lights
     LightSptr light01(new DirectionalLight({1.0f, 1.0f, -1.0f}, glm::vec3(1.0f), 0.1f, 0.5f, 0.5f));
@@ -81,9 +71,6 @@ int main() {
 
     dlTrans = DrawListBuilder::CreateDrawList(liParticleShader);
     dlTrans = DrawListBuilder::AddTransparency(std::move(dlTrans));
-
-    dlText = DrawListBuilder::CreateDrawList(textShader);
-    dlText = DrawListBuilder::AddOrthoProjection(std::move(dlText));
 
     dlSkybox = DrawListBuilder::CreateDrawList(skyboxShader);
 

--- a/3DEngine/Shader.cpp
+++ b/3DEngine/Shader.cpp
@@ -5,7 +5,7 @@
 #include <glm/gtc/type_ptr.hpp>
 
 Shader::Shader(const std::string &name, const PreprocessorList &preprocessors, bool compileNow)
-    : Resource{name}, m_progId(0), m_vertId(0), m_fragId(0) {
+    : Resource{name}, m_isCompiled(false), m_progId(0), m_vertId(0), m_fragId(0) {
   // Generate preprocessor map
   for (const auto &preproc : preprocessors)
     m_preprocessorMap[preproc.type][preproc.name] = preproc.data;
@@ -40,6 +40,7 @@ void Shader::compile() {
     throw std::runtime_error("An error occurred during shader program compilation.");
 
   bindUniforms();
+  m_isCompiled = true;
 }
 
 // Loads shader from file

--- a/3DEngine/Shader.h
+++ b/3DEngine/Shader.h
@@ -51,6 +51,7 @@ public:
 
   void use() const;
   GLint getUniformId(const std::string &param) const;
+  bool isCompiled() const { return m_isCompiled; }
 
   // Uniform setter utility functions
   void setBool(const std::string &name, bool value) const;
@@ -80,6 +81,8 @@ private:
 
   UniformMap m_uniformMap;
   PreprocessorMap m_preprocessorMap;
+
+  bool m_isCompiled;
 
   // Program ids
   GLuint m_progId;

--- a/3DEngine/UiOverlay.cpp
+++ b/3DEngine/UiOverlay.cpp
@@ -9,7 +9,6 @@
 UiOverlay::UiOverlay() : m_toggleOn(true) {
   // Setup shader and draw list
   auto textShader = ResourceManager<Shader>::Get("Text");
-  textShader->compile();
 
   m_dlText = DrawListBuilder::CreateDrawList(textShader);
   m_dlText = DrawListBuilder::AddOrthoProjection(std::move(m_dlText));


### PR DESCRIPTION
This PR makes the following changes:

- Preprocessors are now supplied to the shader's constructor.
- Option to use shader after compilation removed.
- Option to compile shader immediately after creation added.

Closes #10 